### PR TITLE
Added errorformat

### DIFF
--- a/compiler/cpm.vim
+++ b/compiler/cpm.vim
@@ -21,7 +21,8 @@ let b:clean_project_file = glob('*.prj') "FIXME may return multiple files
 let &l:makeprg = 'cpm project ' . b:clean_project_file . ' build'
 
 setlocal isfname-=,
-let &l:errorformat  = '%E%trror [%f\,%l\,]: %m' " General error (without location info)
+let &l:errorformat  = '%E%trror [%f\,%l]: %m' " General error (without location info)
+let &l:errorformat  = ',%E%trror [%f\,%l\,]: %m' " General error (without location info)
 let &l:errorformat .= ',%E%trror [%f\,%l\,%s]: %m' " General error
 let &l:errorformat .= ',%E%type error [%f\,%l\,%s]:%m' " Type error
 let &l:errorformat .= ',%E%tverloading error [%f\,%l\,%s]:%m' " Overloading error

--- a/compiler/cpm.vim
+++ b/compiler/cpm.vim
@@ -22,7 +22,7 @@ let &l:makeprg = 'cpm project ' . b:clean_project_file . ' build'
 
 setlocal isfname-=,
 let &l:errorformat  = '%E%trror [%f\,%l]: %m' " General error (without location info)
-let &l:errorformat  = ',%E%trror [%f\,%l\,]: %m' " General error (without location info)
+let &l:errorformat .= ',%E%trror [%f\,%l\,]: %m' " General error (without location info)
 let &l:errorformat .= ',%E%trror [%f\,%l\,%s]: %m' " General error
 let &l:errorformat .= ',%E%type error [%f\,%l\,%s]:%m' " Type error
 let &l:errorformat .= ',%E%tverloading error [%f\,%l\,%s]:%m' " Overloading error


### PR DESCRIPTION
E.g. the incorrect module header error doesn't have the extra comma in the error.
